### PR TITLE
Añadir codirector

### DIFF
--- a/chapters/configuracion.tex
+++ b/chapters/configuracion.tex
@@ -41,13 +41,20 @@ Los cinco siguientes comandos, como se ve en el listado~\ref{lst:starting-title-
 
 El único misterio es eso de las entradas bibliográficas para el autor y el director. No es más que los nombres que aparecen más adelante cuando se indica \enquote{cómo citar el proyecto}. El día que aprenda cómo hacerlo automáticamente, será una configuración que desaparezca\footnote{Bueno, y si tú, queridísimo lector o lectora sabes cómo hacerlo, hazme un \textit{pull request} al repositorio de la plantilla: \href{\templaterepository}{\templaterepository}.}.
 
+Para incluir un codirector o codirectora, en el caso de que el trabajo lo requiera, simplemente descomenta la línea que verás a continuación (listado \ref{lst:adding-codirector}).
+
+\lstinputlisting[language=tex,firstline=17,lastline=9,caption={Configurando codirector},label=lst:adding-codirector]{report.tex}
+
+El primer parámetro dentro de los corchetes \texttt{[f/m]} indica el género del codirector (\texttt{m} para masculino, \texttt{f} para femenino). A continuación, proporciona el nombre completo del codirector y el nombre para la referencia bibliográfica. Recuerda que esta configuración es opcional, si no se necesita un codirector, simplemente deja esta línea comentada. El documento generará automáticamente la portada y el contenido sin incluir la sección del codirector.
+
+
 Tras ello, empieza el primer contenido de verdad: \textbf{resumen} y \textbf{abstract}, cada uno con sus palabras clave asociadas. Ambos dos son obligatorios y se añaden con la macro \lstinline{\abstract}, donde se especificarán el idioma (\texttt{spanish} o \texttt{english}) y el contenido. De la misma manera, las palabras clave se añaden con la macro \lstinline{\keywords}. Ni que decir tiene que ambos deben tener el mismo contenido, uno en español y el otro en inglés. Y además es obligatorio (según la normativa de la ETSISI).
 
 Existe la opción de añadir agradecimientos a través de la macro \lstinline{\acknowledgements}. Es opcional, así que si no se pone no se renderiza en el documento final, pero es algo bonito y a las abuelas les encanta aparecer ahí. Y las abuelas son de lo más bonito que existe en este mundo, así que cuidadlas.
 
 Y ahora sí, se empieza con el grueso del documento. Tras incluir el glosario, del que se hablará en la sección~\ref{s:glosario} del~\ref{ch:componentes-de-la-plantilla}, se comenzarán a incluir uno tras otro todos los capítulos de los que se compone nuestra memoria, tal y como se muestra en el listado~\ref{lst:starting-include-chapters}.
 
-\lstinputlisting[language=tex,firstline=39,lastline=50,caption={Cómo se incluyen los capítulos y los apéndices},label={lst:starting-include-chapters}]{report.tex}
+\lstinputlisting[language=tex,firstline=41,lastline=52,caption={Cómo se incluyen los capítulos y los apéndices},label={lst:starting-include-chapters}]{report.tex}
 
 La macro \lstinline{\appendix} del medio indica a partir de qué punto se añaden los apéndices. No son obligatorios, ni mucho menos, pero en algunos \glspl{pfg} y \glspl{pfm} se suelen incluir para dar información adicional de contexto que no es el objetivo de la memoria, pero sí interesante para complementar. Por ejemplo, en un \gls{pfm} para el estudio del comportamiento de conductores al volante, uno de los apéndices podría ser cada uno de los formularios que se le ofrecieron para rellenar a cada uno de los conductores de dicho estudio.
 

--- a/report.tex
+++ b/report.tex
@@ -14,6 +14,8 @@
 \director{Directora Proyecto}
 \bibdirector{Proyecto, D.}
 
+% \codirector[f]{Codirectora Proyecto}{Proyecto, C.}
+
 \abstract{spanish}{
     El resumen de un \acrlong{pfg} o de un \acrlong{pfm} condensa en tres o cuatro párrafos el contenido de la memoria. Se debe dar por sentado que el lector podrá tener una idea clara de lo que trata, y suele ser la primera barrera donde decide si continúa leyendo o no el texto.
     

--- a/upm-report.cls
+++ b/upm-report.cls
@@ -43,6 +43,7 @@
 \DeclareStringOption{degree}
 \DeclareStringOption{authorsex}
 \DeclareStringOption{directorsex}
+\DeclareStringOption{codirectorsex}
 \ProcessKeyvalOptions*
 
 % Variables relacionadas con la escuela (arg. 'school')
@@ -176,6 +177,9 @@
     \PackageError{upm-report}{Director sex}{Falta el parámetro 'directorsex'}
 }{}
 
+
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Variables
 %
@@ -186,6 +190,28 @@
 \newcommand{\@director}{\@latex@warning@no@line{No \noexpand\director given}}
 \newcommand{\bibdirector}[1]{\gdef\@bibdirector{#1}}%
 \newcommand{\@bibdirector}{\@latex@warning@no@line{No \noexpand\bibdirector given}}
+
+
+
+
+\newcommand{\codirector}[3][]{%
+    \ifthenelse{\equal{#1}{}}{%
+        % Si el argumento opcional está vacío, establece sólo el nombre del codirector
+        \gdef\@codirector{#2}%
+        \gdef\@codirectorsex{}%
+        \gdef\@bibcodirector{}%
+    }{%
+        % Si se proporciona el argumento opcional, establece tanto el nombre como el sexo del codirector
+        \gdef\@codirector{#2}%
+        \gdef\@codirectorsex{#1}%
+        \gdef\@bibcodirector{#3}%
+    }%
+}
+\newcommand{\@codirector}{} % Inicializar la macro del nombre del codirector para que esté vacía
+\newcommand{\@codirectorsex}{} % Inicializar la macro codirector sex para que esté vacía
+\newcommand{\@bibcodirector}{} % Inicializar la macro nombre del babero codirector para que esté vacía
+
+
 \makeatother
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -464,6 +490,13 @@
             \normalsize
             \textbf{\ifthenelse{\equal{\authorsex}{m}}{Autor}{Autora}}: \@author\\*[1em]
             \textbf{\ifthenelse{\equal{\directorsex}{m}}{Director}{Directora}}: \@director\\*[1em]
+            \ifthenelse{\equal{\@codirectorsex}{m}}{%
+                \textbf{Codirector}: \@codirector\\*[1em]
+            }{\ifthenelse{\equal{\@codirectorsex}{f}}{%
+                \textbf{Codirectora}: \@codirector\\*[1em]
+            }{%
+                % No hacer nada si el parámetro no es 'm' ni 'f
+            }}
             Madrid, \@date
         }
     \end{adjustwidth}
@@ -492,6 +525,13 @@
             {Director}%
             {Directora}%
         }: \@director
+        \ifthenelse{\equal{\@codirectorsex}{m}}{%
+                \\\textbf{Codirector}: \@codirector
+            }{\ifthenelse{\equal{\@codirectorsex}{f}}{%
+                \\\textbf{Codirectora}: \@codirector
+            }{%
+                % No hacer nada si el parámetro no es 'm' ni 'f
+            }}
     }
     
     \par{
@@ -506,7 +546,7 @@
         \texttt{%
             @mastersthesis\{citekey,\\
                 title   = \{\@title\},\\
-                author  = \{\@bibauthor~\textbackslash\& \@bibdirector \}\\
+                author  = \{\@bibauthor~\textbackslash\& \@bibdirector \ifx\@codirectorsex\@empty\else~\textbackslash\& \@bibcodirector \fi \},\\
                 school  = \{\schoolname\},\\
                 year    = \{\the\year\},\\
                 month   = \{\the\month\},\\


### PR DESCRIPTION
He realizado algunos cambios en la plantilla de Latex para facilitar la inclusión del codirector o codirectora del trabajo. Estos son los detalles de la pull request:

- He modificado el fichero `chapters/configuracion.tex` para añadir una línea comentada que permite definir el codirector/a si se desea.
- He modificado el fichero `report.tex` para explicar cómo usar esta opción y qué parámetros se deben proporcionar.
- He modificado el fichero` upm-report.cls` para implementar la lógica que genera la portada y el contenido con el codirector/a si se ha definido.

Para probar esta funcionalidad, se puede seguir estos pasos:

1. Descomentar la línea ` \codirector[f]{Codirectora Proyecto}{Proyecto, C.} `en el fichero `chapters/configuracion.tex`
2. Indicar el género del codirector/a con el primer parámetro entre corchetes: `[f]` para femenino, `[m]` para masculino.
3. Indicar el nombre completo del codirector/a y el nombre para la cita bibliográfica con los siguientes parámetros entre llaves.
4. Compilar el documento y verificar que la portada y en la página siguiente de la licencia, se incluyen la sección del codirector/a.

Espero que esta pull request sea de utilidad.

Próximamente... plantilla para la URJC 😅