### PR TITLE
Makefile para facilitar compilación local y cambios estéticos menores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Makefile build directory
+build/

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,15 @@ all:
 unix:
 	mkdir -p $(BUILD_DIR)
 	cp -rv $$(ls -A | grep -vwE "build|.git") build
+
+	# If your document contains references, or ToC, LoT, LoF material, at least three times. The reasoning is pretty simple:
+	# First pass creates the labels and ToC, LoT, LoF material. Second pass has everything, but due to changes in layout and
+	# the additional material that wasn't available during first pass, the page numbers might change.
+	# Third pass is the first one that might be correct, but there could still be some changes affecting cross-referencing,
+	# so you might need more than three.
+
 	-cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
-	-cd $(BUILD_DIR) && biber $(MAIN_TEX)
-	-cd $(BUILD_DIR) && makeglossaries $(MAIN_TEX)
+	-cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	
 win:
@@ -21,9 +27,15 @@ win:
 	If (-Not (Test-Path -Path $$BuildDir)) { New-Item -ItemType Directory -Path $$BuildDir }; \
 	Get-ChildItem -Path . -Exclude $$BuildDir, '.git' | Copy-Item -Destination $$BuildDir -Recurse -Force; \
 	Set-Location -Path $$BuildDir; \
+
+	# If your document contains references, or ToC, LoT, LoF material, at least three times. The reasoning is pretty simple:
+	# First pass creates the labels and ToC, LoT, LoF material. Second pass has everything, but due to changes in layout and
+	# the additional material that wasn't available during first pass, the page numbers might change.
+	# Third pass is the first one that might be correct, but there could still be some changes affecting cross-referencing,
+	# so you might need more than three.
+	
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
-	biber $$MainTex; \
-	makeglossaries $$MainTex; \
+	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	}"
 	

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ win:
 	If (-Not (Test-Path -Path $$BuildDir)) { New-Item -ItemType Directory -Path $$BuildDir }; \
 	Get-ChildItem -Path . -Exclude $$BuildDir, '.git' | Copy-Item -Destination $$BuildDir -Recurse -Force; \
 	Set-Location -Path $$BuildDir; \
-	xelatex \"$$MainTex.tex\"; \
+	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	biber $$MainTex; \
 	makeglossaries $$MainTex; \
-	xelatex \"$$MainTex.tex\"; \
+	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	}"
 	
 clean:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ win:
 	Set-Location -Path $$BuildDir; \
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	makeglossaries $(MAIN_TEX)
-	biber $(MAIN_TEX).tex
+	biber $(MAIN_TEX)
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	}

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ all:
 unix:
 	mkdir -p $(BUILD_DIR)
 	cp -rv $$(ls -A | grep -vwE "build|.git") build
-	-cd $(BUILD_DIR) && xelatex $(MAIN_TEX).tex
+	-cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	-cd $(BUILD_DIR) && biber $(MAIN_TEX)
 	-cd $(BUILD_DIR) && makeglossaries $(MAIN_TEX)
-	cd $(BUILD_DIR) && xelatex $(MAIN_TEX).tex
+	cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	
 win:
 	@echo off

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,18 @@ BUILD_DIR=build
 all:
 	$(info Ejecuta make con el target 'unix' o 'win' según tu sistema operativo.)
 
-
 # If your document contains references, or ToC, LoT, LoF material, at least three times. The reasoning is pretty simple:
 # First pass creates the labels and ToC, LoT, LoF material. Second pass has everything, but due to changes in layout and
 # the additional material that wasn't available during first pass, the page numbers might change.
 # Third pass is the first one that might be correct, but there could still be some changes affecting cross-referencing,
 # so you might need more than three. -- [Skillmon](https://tex.stackexchange.com/users/117050/skillmon) 
 
-
 unix:
 	mkdir -p $(BUILD_DIR)
 	cp -rv $$(ls -A | grep -vwE "build|.git") build
 	-cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
+	-cd $(BUILD_DIR) && makeglossaries $(MAIN_TEX)
+	-cd $(BUILD_DIR) && biber $(MAIN_TEX)
 	-cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	
@@ -29,9 +29,11 @@ win:
 	Get-ChildItem -Path . -Exclude $$BuildDir, '.git' | Copy-Item -Destination $$BuildDir -Recurse -Force; \
 	Set-Location -Path $$BuildDir; \
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
+	makeglossaries $(MAIN_TEX)
+	biber $(MAIN_TEX).tex
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
-	}"
+	}
 	
 clean:
 	$(info Ejecuta make con el target 'clean-unix' o 'clean-win' según tu sustema operativo.)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+MAIN_TEX=report
+REF_BIB=references
+BUILD_DIR=build
+
+all:
+	$(info Ejecuta make con el target 'unix' o 'win' según tu sistema operativo.)
+
+unix:
+	mkdir -p $(BUILD_DIR)
+	cp -rv $$(ls -A | grep -vwE "build|.git") build
+	-cd $(BUILD_DIR) && xelatex $(MAIN_TEX).tex
+	-cd $(BUILD_DIR) && biber $(MAIN_TEX)
+	-cd $(BUILD_DIR) && makeglossaries $(MAIN_TEX)
+	cd $(BUILD_DIR) && xelatex $(MAIN_TEX).tex
+	
+win:
+	@echo off
+	powershell -Command "& {\
+	$$BuildDir = '$(BUILD_DIR)'; \
+	$$MainTex = '$(MAIN_TEX)'; \
+	If (-Not (Test-Path -Path $$BuildDir)) { New-Item -ItemType Directory -Path $$BuildDir }; \
+	Get-ChildItem -Path . -Exclude $$BuildDir, '.git' | Copy-Item -Destination $$BuildDir -Recurse -Force; \
+	Set-Location -Path $$BuildDir; \
+	xelatex \"$$MainTex.tex\"; \
+	biber $$MainTex; \
+	makeglossaries $$MainTex; \
+	xelatex \"$$MainTex.tex\"; \
+	}"
+	
+clean:
+	$(info Ejecuta make con el target 'clean-unix' o 'clean-win' según tu sustema operativo.)
+	
+clean-unix:
+	rm -rf $(BUILD_DIR)
+	
+clean-win:
+	cmd /c rd /s /q $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,17 @@ BUILD_DIR=build
 all:
 	$(info Ejecuta make con el target 'unix' o 'win' según tu sistema operativo.)
 
+
+# If your document contains references, or ToC, LoT, LoF material, at least three times. The reasoning is pretty simple:
+# First pass creates the labels and ToC, LoT, LoF material. Second pass has everything, but due to changes in layout and
+# the additional material that wasn't available during first pass, the page numbers might change.
+# Third pass is the first one that might be correct, but there could still be some changes affecting cross-referencing,
+# so you might need more than three. -- [Skillmon](https://tex.stackexchange.com/users/117050/skillmon) 
+
+
 unix:
 	mkdir -p $(BUILD_DIR)
 	cp -rv $$(ls -A | grep -vwE "build|.git") build
-
-	# If your document contains references, or ToC, LoT, LoF material, at least three times. The reasoning is pretty simple:
-	# First pass creates the labels and ToC, LoT, LoF material. Second pass has everything, but due to changes in layout and
-	# the additional material that wasn't available during first pass, the page numbers might change.
-	# Third pass is the first one that might be correct, but there could still be some changes affecting cross-referencing,
-	# so you might need more than three.
-
 	-cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	-cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
 	cd $(BUILD_DIR) && xelatex -interaction nonstopmode -file-line-error $(MAIN_TEX).tex
@@ -27,13 +28,6 @@ win:
 	If (-Not (Test-Path -Path $$BuildDir)) { New-Item -ItemType Directory -Path $$BuildDir }; \
 	Get-ChildItem -Path . -Exclude $$BuildDir, '.git' | Copy-Item -Destination $$BuildDir -Recurse -Force; \
 	Set-Location -Path $$BuildDir; \
-
-	# If your document contains references, or ToC, LoT, LoF material, at least three times. The reasoning is pretty simple:
-	# First pass creates the labels and ToC, LoT, LoF material. Second pass has everything, but due to changes in layout and
-	# the additional material that wasn't available during first pass, the page numbers might change.
-	# Third pass is the first one that might be correct, but there could still be some changes affecting cross-referencing,
-	# so you might need more than three.
-	
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \
 	xelatex -interaction nonstopmode -file-line-error \"$$MainTex.tex\"; \

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ la plantilla directamente para su uso
 ## Compilación Rápida
 
 Hay un documento Makefile en el repositorio que permite compilar facilmente el pdf.
-Para compilar haciendo su uso simplemente se ejecuta make con el target `unix` si se está usando
-un sistema operativo unix-like o `win` en caso de Windows.
+Para compilar haciendo su uso, se ejecuta make con el target `unix` o `win` dependiendo del sistema operativo.
 
 ## Contribución
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ O también puedes usar el editor de textos Overleaf, online y que tiene disponib
 la plantilla directamente para su uso
 [en este enlace](https://es.overleaf.com/latex/templates/upm-report-template/sxtmzsytgthp)
 
+## Compilación Rápida
+
+Hay un documento Makefile en el repositorio que permite compilar facilmente el pdf.
+Para compilar haciendo su uso simplemente se ejecuta make con el target `unix` si se está usando
+un sistema operativo unix-like o `win` en caso de Windows.
+
 ## Contribución
 
 Si deseas contribuir a este proyecto, puedes realizar los siguientes pasos:

--- a/chapters/componentes.tex
+++ b/chapters/componentes.tex
@@ -429,7 +429,13 @@ En esta entrada, \texttt{@tipo} indica el tipo de elemento (p. ej. \texttt{@arti
 
 \subsection{¿De qué manera puedo citar las referencias?}
 
-TBD~\cite{mcculloch1943logical}
+Para citar una referencia en el cuerpo del texto, utilizamos la etiqueta \texttt{cite}, tal como se muestra en el listado~\ref{lst:bib-references}, con el identificador de la referencia bibliográfica previamente definida en el archivo \textit{references.bib}, como se ilustra en el listado~\ref{lst:base-bibref}.
+
+\begin{lstlisting}[language=tex, caption=Referenciando una entrada bibliográfica,label={lst:bib-references},]
+Según lo expuesto en \cite{mcculloch1943logical}, se observa que...
+\end{lstlisting}
+
+Esto generará una cita en el lugar correspondiente del texto y agregará automáticamente la referencia completa en la bibliografía.
 
 \section{Referencias cruzadas}
 

--- a/chapters/componentes.tex
+++ b/chapters/componentes.tex
@@ -436,6 +436,7 @@ Según lo expuesto en \cite{mcculloch1943logical}, se observa que...
 \end{lstlisting}
 
 Esto generará una cita en el lugar correspondiente del texto y agregará automáticamente la referencia completa en la bibliografía.
+El aspecto de la cita es una cajita como la siguiente con el número de la referencia \cite{mcculloch1943logical}.
 
 \section{Referencias cruzadas}
 

--- a/upm-report.cls
+++ b/upm-report.cls
@@ -24,7 +24,7 @@
 \RequirePackage{ifthen}     % Para poder usar condicionales en la clase
 \RequirePackage{pdflscape}  % Posibilidad de páginas en apaisado
 \RequirePackage{xcolor}     % Mejoras sobre el paquete color
-\RequirePackage{tocloft}  % Añadir indice de ecuaciones
+\RequirePackage{tocloft}    % Añadir indice de ecuaciones
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Valores constantes

--- a/upm-report.cls
+++ b/upm-report.cls
@@ -500,6 +500,7 @@
 \renewcommand\maketitle{{
     \sffamily
     \thispagestyle{empty}
+    \pagenumbering{gobble}
     % Barra lateral izquierda y logo fondo
     \AddToShipoutPicture*{%
         \AtPageLowerLeft{%
@@ -545,6 +546,7 @@
     \footnotesize
     \clearpage
     \thispagestyle{empty}
+    \pagenumbering{gobble}
     ~\vfill
     \par{
         \textit{\@title}\\
@@ -589,6 +591,7 @@
     \ifthenelse{\equal{\@acknowledgements}{}}{}{
         \clearpage
         \thispagestyle{empty}
+        \pagenumbering{gobble}
         \chapter*{Agradecimientos}
         \@acknowledgements
     }
@@ -611,6 +614,7 @@
 \newcommand\makeresumen{{
     \clearpage
     \thispagestyle{empty}
+    \pagenumbering{gobble}
     \chapter*{Resumen}
     \@abstractsp
 
@@ -620,6 +624,7 @@
 \newcommand\makeabstract{{
     \clearpage
     \thispagestyle{empty}
+    \pagenumbering{gobble}
     \chapter*{Abstract}
     \@abstracten
 
@@ -642,6 +647,7 @@
 \newcommand{\makebackcover}{
     \clearpage
     \thispagestyle{empty}
+    \pagenumbering{gobble}
     \pagecolor{schoolcolor}
     \AddToShipoutPicture*{%
         \put(0,0){%

--- a/upm-report.cls
+++ b/upm-report.cls
@@ -390,6 +390,7 @@
     unicode=true,
     colorlinks=true,
     linkcolor={linkcolor},
+    citecolor={linkcolor},
 }
 \makeatother
 


### PR DESCRIPTION
Cambios:
- Se añade un Makefile que permite compilar el documento tanto en sistemas unix-like como en windows facilmente: `make unix` o `make win`.
- Los links de las referencias bibliográficas se cambian del color verde por defecto al color universitario.
- Sección "3.9.2. ¿De qué manera puedo citar las referencias?" del documento explicnado como citar referencias bibliográficas escrito.
- Arreglar los links del glosario. Anteriormente apuntaban asumiendo que la primera página es la 1 y por tanto se pasaban un par de páginas por arriba.